### PR TITLE
a bug on "multiplicative"

### DIFF
--- a/lab/craft/SimpleParser.java
+++ b/lab/craft/SimpleParser.java
@@ -242,7 +242,7 @@ public class SimpleParser {
             Token token = tokens.peek();
             if (token != null && (token.getType() == TokenType.Star || token.getType() == TokenType.Slash)) {
                 token = tokens.read();
-                SimpleASTNode child2 = primary(tokens);
+                SimpleASTNode child2 = multiplicative(tokens);
                 if (child2 != null) {
                     node = new SimpleASTNode(ASTNodeType.Multiplicative, token.getText());
                     node.addChild(child1);


### PR DESCRIPTION
应该是：
multiplicative : primary | primary * multiplicative
而不是：
multiplicative : primary | primary * primary